### PR TITLE
service.json generation

### DIFF
--- a/src/service/meta.json
+++ b/src/service/meta.json
@@ -7,9 +7,10 @@
       "choices": [
         {
           "name": "Memory",
-          "checked": false,
+          "checked": true,
           "value": {
-            "name": "feathers-memory",
+            "template": "memory",
+            "require": "feathers-memory",
             "deps": ["feathers-memory"]
           }
         },
@@ -17,10 +18,21 @@
           "name": "NeDB",
           "checked": true,
           "value": {
-            "name": "feathers-nedb",
+            "template": "nedb",
+            "require": "feathers-nedb",
             "deps": ["nedb", "feathers-nedb"]
           }
+        },
+        {
+          "name": "Mongoose",
+          "checked": false,
+          "value": {
+            "template": "mongoose",
+            "require": "feathers-mongoose",
+            "deps": ["mongoose", "feathers-mongoose"]
+          }
         }
+
       ]
     }
   ]

--- a/src/service/meta.json
+++ b/src/service/meta.json
@@ -31,8 +31,16 @@
             "require": "feathers-mongoose",
             "deps": ["mongoose", "feathers-mongoose"]
           }
+        },
+        {
+          "name": "None",
+          "checked": false,
+          "value": {
+            "template": false,
+            "require": false,
+            "deps": false
+          }
         }
-
       ]
     }
   ]

--- a/src/service/middleware/model.js
+++ b/src/service/middleware/model.js
@@ -8,7 +8,7 @@ const debug = require('debug')('feathers-generator:model');
 export default function (options) {
   return function mount (files, metalsmith, done) {
     const meta = metalsmith.metadata();
-    let model = meta.answers.model.name;
+    let model = meta.answers.model.template;
     let deps = meta.answers.model.deps;
 
     each(

--- a/src/service/middleware/model.js
+++ b/src/service/middleware/model.js
@@ -8,6 +8,10 @@ const debug = require('debug')('feathers-generator:model');
 export default function (options) {
   return function mount (files, metalsmith, done) {
     const meta = metalsmith.metadata();
+
+    // no model selected
+    if(meta.answers.model === false) return done();
+
     let model = meta.answers.model.template;
     let deps = meta.answers.model.deps;
 

--- a/src/service/middleware/model.js
+++ b/src/service/middleware/model.js
@@ -9,9 +9,6 @@ export default function (options) {
   return function mount (files, metalsmith, done) {
     const meta = metalsmith.metadata();
 
-    // no model selected
-    if(meta.answers.model === false) return done();
-
     let model = meta.answers.model.template;
     let deps = meta.answers.model.deps;
 
@@ -25,7 +22,7 @@ export default function (options) {
         }
 
         // filter out non-selected models
-        if (!match(file, `models/${model}/**/*.js`).length) {
+        if (!match(file, `models/${model}/templates/*.*`).length) {
           debug(`filtering out ${file}`);
           delete files[file];
         }

--- a/src/service/middleware/rename.js
+++ b/src/service/middleware/rename.js
@@ -5,7 +5,7 @@ const debug = require('debug')('feathers-generator:rename');
 export default function (options) {
   return function rename (files, metalsmith, done) {
     const meta = metalsmith.metadata();
-    let model = meta.answers.model.name;
+    let model = meta.answers.model.template;
 
     each(
       Object.keys(files),

--- a/src/service/middleware/rename.js
+++ b/src/service/middleware/rename.js
@@ -5,7 +5,6 @@ const debug = require('debug')('feathers-generator:rename');
 export default function (options) {
   return function rename (files, metalsmith, done) {
     const meta = metalsmith.metadata();
-    let model = meta.answers.model.template;
 
     each(
       Object.keys(files),
@@ -17,6 +16,10 @@ export default function (options) {
           delete files[file];
         }
 
+        // skip if no model selected
+        if(meta.answers.model === false) return next();
+
+        let model = meta.answers.model.template;
         if (match(file, `models/${model}/**/*.js`).length) {
           let newModelName = file.replace(`models/${model}/templates/service`, options.name);
           debug(`Renaming template ${file} to ${newModelName}`);

--- a/src/service/middleware/rename.js
+++ b/src/service/middleware/rename.js
@@ -20,7 +20,7 @@ export default function (options) {
         if(meta.answers.model === false) return next();
 
         let model = meta.answers.model.template;
-        if (match(file, `models/${model}/**/*.js`).length) {
+        if (match(file, `models/${model}/templates/*.*`).length) {
           let newModelName = file.replace(`models/${model}/templates/service`, options.name);
           debug(`Renaming template ${file} to ${newModelName}`);
           files[newModelName] = files[file];

--- a/src/service/templates/models/memory/templates/service.json
+++ b/src/service/templates/models/memory/templates/service.json
@@ -2,7 +2,7 @@
   "require": "feathers-memory",
   "options": {
     "Model": {
-      "require": "./service.model",
+      "require": "./{{options.name}}.model",
       "options": { }
     },
     "paginate": "config.paginate"

--- a/src/service/templates/models/memory/templates/service.json
+++ b/src/service/templates/models/memory/templates/service.json
@@ -1,10 +1,16 @@
 {
-  "require": "feathers-memory",
-  "options": {
+  "require": "{{answers.model.require}}",
+  "options": [{
     "Model": {
       "require": "./{{options.name}}.model",
-      "options": { }
+      "options": []
     },
     "paginate": "config.paginate"
+  }],
+  "filter": {
+    "all": {
+      "require": "./{{options.name}}.filter",
+      "options": []
+    }
   }
 }

--- a/src/service/templates/models/mongoose/templates/service.json
+++ b/src/service/templates/models/mongoose/templates/service.json
@@ -1,7 +1,7 @@
 {
   "require": "feathers-mongoose",
   "options": {
-    "model": "./service.model",
+    "model": "./{{options.name}}.model",
     "paginate": "config.paginate"
   }
 }

--- a/src/service/templates/models/mongoose/templates/service.json
+++ b/src/service/templates/models/mongoose/templates/service.json
@@ -1,7 +1,16 @@
 {
-  "require": "feathers-mongoose",
-  "options": {
-    "model": "./{{options.name}}.model",
+  "require": "{{answers.model.require}}",
+  "options": [{
+    "Model": {
+      "require": "./{{options.name}}.model",
+      "options": [{  }]
+    },
     "paginate": "config.paginate"
+  }],
+  "filter": {
+    "all": {
+      "require": "./{{options.name}}.filter",
+      "options": []
+    }
   }
 }

--- a/src/service/templates/models/mongoose/templates/service.model.js
+++ b/src/service/templates/models/mongoose/templates/service.model.js
@@ -1,2 +1,8 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
+
+module.exports = function (options) {
+  var Service = new Schema({}, { strict: false });
+  var Model = mongoose.model(options.name, Service);
+  return Model;
+};

--- a/src/service/templates/models/nedb/templates/service.json
+++ b/src/service/templates/models/nedb/templates/service.json
@@ -6,7 +6,6 @@
       "options": [{
         "db": "{{options.name}}",
         "path": "config.{{answers.model.template}}.path"
-
       }]
     },
     "paginate": "config.paginate"

--- a/src/service/templates/models/nedb/templates/service.json
+++ b/src/service/templates/models/nedb/templates/service.json
@@ -2,7 +2,7 @@
   "require": "feathers-nedb",
   "options": {
     "Model": {
-      "require": "./service.model",
+      "require": "./{{options.name}}.model",
       "options": { "nedb": "config.nedb" }
     },
     "paginate": "config.paginate"

--- a/src/service/templates/models/nedb/templates/service.json
+++ b/src/service/templates/models/nedb/templates/service.json
@@ -1,10 +1,20 @@
 {
-  "require": "feathers-nedb",
-  "options": {
+  "require": "{{answers.model.require}}",
+  "options": [{
     "Model": {
       "require": "./{{options.name}}.model",
-      "options": { "nedb": "config.nedb" }
+      "options": [{
+        "db": "{{options.name}}",
+        "path": "config.{{answers.model.template}}.path"
+
+      }]
     },
     "paginate": "config.paginate"
+  }],
+  "filter": {
+    "all": {
+      "require": "./{{options.name}}.filter",
+      "options": []
+    }
   }
 }

--- a/src/service/templates/models/nedb/templates/service.model.js
+++ b/src/service/templates/models/nedb/templates/service.model.js
@@ -4,7 +4,7 @@ const NeDB = require('nedb');
 module.exports = function (options) {
   // Create a NeDB instance
   return new NeDB({
-    filename: path.join(options.path, 'messages.db'),
+    filename: path.join(options.path, options.db+'.db'),
     autoload: true
   });
 };

--- a/src/service/templates/models/nedb/templates/service.model.js
+++ b/src/service/templates/models/nedb/templates/service.model.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const NeDB = require('nedb');
 
-module.exports = function(options) {
+module.exports = function (options) {
   // Create a NeDB instance
   return new NeDB({
     filename: path.join(options.path, 'messages.db'),

--- a/src/service/templates/service.json
+++ b/src/service/templates/service.json
@@ -1,13 +1,16 @@
 {
-  "require": "{{answers.model.name}}",
+  "require": "{{answers.model.require}}",
   "options": [{
-    "paginate": "config.paginate",
     "Model": {
-      "require": "./test.model",
-      "options": [{ "path": "config.{{answers.model.name}}.path", "db": "{{options.name}}" }]
-    }
+      "require": "./{{options.name}}.model",
+      "options": []
+    },
+    "paginate": "config.paginate"
   }],
   "filter": {
-    "all": { "require": "./test.filter", "options": [] }
+    "all": {
+      "require": "./{{options.name}}.filter",
+      "options": []
+    }
   }
 }

--- a/src/service/templates/service.model.js
+++ b/src/service/templates/service.model.js
@@ -1,9 +1,5 @@
-const path = require('path');
-const NeDB = require('nedb');
+// default empty model
 
 module.exports = function (options) {
-  return new NeDB({
-    filename: path.join(options.path, options.db+'.db'),
-    autoload: true
-  });
+
 };


### PR DESCRIPTION
### overview

When generating services with models, we should build the `service.json` dynamically, by including the definitions defined in each model, rather then using a single template with handlebars.

Eventually, this will need to be built from multiple assets (hooks, filters etcs) but for now it will just be built from models as those are the only prompt configurations supported so far.

### tasks
- [x] grab `service.json` from model templates
- [x] overwrite `{{options.template}}.json` in file pipeline
- [x] ensure that all `service.json` have sane defaults for non generated resources
