### PR TITLE
default hooks + filters

### DIFF
--- a/src/service/templates/hooks/after.js
+++ b/src/service/templates/hooks/after.js
@@ -1,5 +1,14 @@
 module.exports = function() {
+
+  if(process.env.NODE_ENV !== 'production') {
+    console.warn(`You are using the default after hook for the {{options.name}} service (in ${__dirname}).`);
+    console.warn(`This hook will not do anything except log to stdout.`);
+    console.warn(`For more information on how hooks work see: https://docs.feathersjs.com/hooks/readme.html`);
+    console.warn(``);
+  }
+
   return function(hook) {
     // do something here
+    console.log(`{{options.name}} after hook executed`);
   };
 };

--- a/src/service/templates/hooks/before.js
+++ b/src/service/templates/hooks/before.js
@@ -1,5 +1,14 @@
 module.exports = function() {
+
+  if(process.env.NODE_ENV !== 'production') {
+    console.warn(`You are using the default before hook for the {{options.name}} service (in ${__dirname}).`);
+    console.warn(`This hook will not do anything except log to stdout.`);
+    console.warn(`For more information on how hooks work see: https://docs.feathersjs.com/hooks/readme.html`);
+    console.warn(``);
+  }
+
   return function(hook) {
     // do something here
+    console.log(`{{options.name}} before hook executed`);
   };
 };

--- a/src/service/templates/models/memory/templates/service.json
+++ b/src/service/templates/models/memory/templates/service.json
@@ -7,6 +7,12 @@
     },
     "paginate": "config.paginate"
   }],
+  "before":{
+    "all": [{ "require": "./hooks/before", "options": [] }]
+  },
+  "after":{
+    "all": [{ "require": "./hooks/after", "options": [] }]
+  },
   "filter": {
     "all": {
       "require": "./{{options.name}}.filter",

--- a/src/service/templates/models/mongoose/templates/service.json
+++ b/src/service/templates/models/mongoose/templates/service.json
@@ -10,6 +10,12 @@
     },
     "paginate": "config.paginate"
   }],
+  "before":{
+    "all": [{ "require": "./hooks/before", "options": [] }]
+  },
+  "after":{
+    "all": [{ "require": "./hooks/after", "options": [] }]
+  },
   "filter": {
     "all": {
       "require": "./{{options.name}}.filter",

--- a/src/service/templates/models/nedb/templates/service.json
+++ b/src/service/templates/models/nedb/templates/service.json
@@ -10,6 +10,12 @@
     },
     "paginate": "config.paginate"
   }],
+  "before":{
+    "all": [{ "require": "./hooks/before", "options": [] }]
+  },
+  "after":{
+    "all": [{ "require": "./hooks/after", "options": [] }]
+  },
   "filter": {
     "all": {
       "require": "./{{options.name}}.filter",

--- a/src/service/templates/service.filter.js
+++ b/src/service/templates/service.filter.js
@@ -1,9 +1,13 @@
 module.exports = function() {
   if(process.env.NODE_ENV !== 'production') {
-    console.warn(`You are using the default filter for the \`{{options.name}}\` service (in ${__dirname}). This means all clients will get every real-time event. For more information how to filter events see http://docs.feathersjs.com/real-time/filtering.html`);
+    console.warn(`You are using the default filter for the \`{{options.name}}\` service (in ${__dirname}).`);
+    console.warn(`This means all clients will get every real-time event.`);
+    console.warn(`For more information how to filter events see http://docs.feathersjs.com/real-time/filtering.html`);
+    console.warn(``);
   }
 
   return function() {
+    console.log(`{{options.name}} filter returned: true`);
     return true;
   };
 };

--- a/src/service/templates/service.json
+++ b/src/service/templates/service.json
@@ -7,6 +7,12 @@
     },
     "paginate": "config.paginate"
   }],
+  "before":{
+    "all": [{ "require": "./hooks/before", "options": [] }]
+  },
+  "after":{
+    "all": [{ "require": "./hooks/after", "options": [] }]
+  },
   "filter": {
     "all": {
       "require": "./{{options.name}}.filter",


### PR DESCRIPTION
### overview

I accidentally removed the default `before` and `after` hooks from the `service.json` in each model. This should be added back before I move onto fully dynamic configuration - also I need to make sure that both default filters and hooks are actually executed after generating the service.

### tasks
- [x] add back hooks to memory
- [x] add back hooks to nedb
- [x] add back hooks to mongoose
- [x] add back hooks to none
- [x] ensure default hooks and filters work 

### screenshot
![screenshot 2016-11-12 13 02 27](https://cloud.githubusercontent.com/assets/18702/20240860/4b36a0d8-a8d8-11e6-85a6-663932c9cd0f.png)
