### PR TITLE
middleware

### DIFF
--- a/src/filter/generator.js
+++ b/src/filter/generator.js
@@ -22,7 +22,7 @@ module.exports = function (prompt, done, options) {
 
   debug('Template path: %s', TEMPLATE_PATH);
   debug('Service path: %s', SERVICE_PATH);
-  debug('Hook path: %s', FILTER_PATH);
+  debug('Filter path: %s', FILTER_PATH);
   debug('Feathers path: %s', FEATHERS_PATH);
   debug('Mount path: %s', MOUNT_PATH);
   debug('Config path: %s', CONFIG_PATH);

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 import app from './app/generator';
 import hook from './hook/generator';
 import filter from './filter/generator';
-// import middleware from './middleware/generator';
+import middleware from './middleware/generator';
 // import plugin from './plugin/generator';
 import service from './service/generator';
 
@@ -10,7 +10,7 @@ const generators = {
   app,
   hook,
   filter,
-  // middleware,
+  middleware,
   // plugin,
   service
 };

--- a/src/middleware/generator.js
+++ b/src/middleware/generator.js
@@ -15,7 +15,7 @@ import { middleware as mount } from '../utils/mount';
 module.exports = function (prompt, done, options) {
   const metalsmith = Metalsmith(TEMPLATE_PATH);
   const SERVICE_PATH = path.resolve(options.path);
-  const MW_PATH = path.resolve('./server/middleware');
+  const MW_PATH = path.resolve(options.root, 'server/middleware');
   const FEATHERS_PATH = 'server/feathers.json';
   const MOUNT_PATH = options.mount || 'server/feathers.json';
   const CONFIG_PATH = options.config || 'config';

--- a/src/middleware/generator.js
+++ b/src/middleware/generator.js
@@ -1,0 +1,59 @@
+const path = require('path');
+const debug = require('debug')('feathers-generator:middleware');
+
+// Metalsmith + middleware
+const Metalsmith = require('metalsmith');
+
+const TEMPLATE_PATH = path.resolve(__dirname, 'templates');
+const render = require('../utils/render');
+const json = require('../utils/json');
+const ask = require('../utils/ask');
+
+import { middleware as rename } from '../utils/rename';
+import { middleware as mount } from '../utils/mount';
+
+module.exports = function (prompt, done, options) {
+  const metalsmith = Metalsmith(TEMPLATE_PATH);
+  const SERVICE_PATH = path.resolve(options.path);
+  const MW_PATH = path.resolve('./server/middleware');
+  const FEATHERS_PATH = 'server/feathers.json';
+  const MOUNT_PATH = options.mount || 'server/feathers.json';
+  const CONFIG_PATH = options.config || 'config';
+
+  debug('Template path: %s', TEMPLATE_PATH);
+  debug('Service path: %s', SERVICE_PATH);
+  debug('Middleware path: %s', MW_PATH);
+  debug('Feathers path: %s', FEATHERS_PATH);
+  debug('Mount path: %s', MOUNT_PATH);
+  debug('Config path: %s', CONFIG_PATH);
+
+  metalsmith
+    .metadata({ options })
+    // Read in any existing config files and attach to metadata
+    // TODO slajax or EK refactor option args into util fn so not duplicated
+    .use(json({
+      meta: path.resolve(__dirname, 'meta.json'),
+      default: path.join(options.root, CONFIG_PATH, 'default.json'),
+      staging: path.join(options.root, CONFIG_PATH, 'staging.json'),
+      production: path.join(options.root, CONFIG_PATH, 'production.json'),
+      feathers: path.join(options.root, FEATHERS_PATH),
+      service: path.join(options.root, MOUNT_PATH),
+      pkg: path.join(options.root, 'package.json')
+    }))
+    .clean(false)
+    .source(TEMPLATE_PATH)
+    .destination(MW_PATH)
+    .use(ask({ callback: prompt }))
+    .use(rename(options)) // rename files for convention
+    .use(mount(options)) // mount filter for bootstrap
+    .use(render()) // pass files through handlebars templating
+    .build(function (error) {
+      if (error) {
+        return done(error);
+      }
+
+      let message = `Successfully generated "${options.name}" ${options.template} at ${MW_PATH}`;
+      debug(message);
+      done(null, message);
+    });
+};

--- a/src/middleware/meta.json
+++ b/src/middleware/meta.json
@@ -1,0 +1,57 @@
+{
+  "prompts": [
+    {
+      "name": "binding",
+      "type": "checkbox",
+      "message": "When would you like this middleware to execute?",
+      "choices": [
+        {
+          "name": "Before the service runs",
+          "value": "before",
+          "checked": true
+        },
+        {
+          "name": "After the service runs",
+          "value": "after"
+        }
+      ]
+    },
+    {
+      "name": "method",
+      "type": "checkbox",
+      "message": "On what action(s) would you like this middleware to execute?",
+      "choices": [
+        {
+          "name": "all",
+          "value": "all",
+          "checked": true
+        },
+        {
+          "name": "get",
+          "value": "get"
+        },
+        {
+          "name": "find",
+          "value": "find"
+        },
+        {
+          "name": "create",
+          "value": "create"
+        },
+        {
+          "name": "update",
+          "value": "update"
+        },
+        {
+          "name": "patch",
+          "value": "patch"
+        },
+        {
+          "name": "remove",
+          "value": "remove"
+        }
+      ]
+    }
+
+  ]
+}

--- a/src/middleware/templates/middleware.js
+++ b/src/middleware/templates/middleware.js
@@ -1,0 +1,18 @@
+module.exports = function () {
+  function log () {
+    if (process.env.NODE_ENV !== 'testing') {
+      console.log(...arguments);
+    }
+  }
+
+  log(`You are using the default generated configuration for the \`{{options.name}}\` middleware (in ${__dirname}).`);
+  log(`This means this middleware has no effect currently.`);
+  log(`For more information how to use middleware see https://docs.feathersjs.com/middleware/readme.html`);
+  log(``);
+
+  return function (data, connection, hook) {
+    log(`generated {{options.name}} filter executed`);
+    data.ran = true;
+    return data;
+  };
+};

--- a/src/middleware/templates/middleware.js
+++ b/src/middleware/templates/middleware.js
@@ -11,7 +11,7 @@ module.exports = function () {
   log(``);
 
   return function (data, connection, hook) {
-    log(`generated {{options.name}} filter executed`);
+    log(`generated {{options.name}} middleware executed`);
     data.ran = true;
     return data;
   };

--- a/src/middleware/templates/middleware.test.js
+++ b/src/middleware/templates/middleware.test.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const createMiddleware = require('./{{options.name}}');
+
+describe('{{options.name}} middleware tests', function () {
+  it('middleware ran', function () {
+    const mw = createMiddleware();
+    assert.equal(mw({}).ran, true);
+  });
+});

--- a/src/utils/mount.js
+++ b/src/utils/mount.js
@@ -167,7 +167,7 @@ export function middleware (options) {
         debug(`Compiling changes for ${b} bindings and ${m} method`);
 
         let hook = {
-          require: './middleware/' + options.name + '.js',
+          require: path.resolve(options.root, 'server/middleware', options.name + '.js'),
           options: []
         };
 

--- a/src/utils/mount.js
+++ b/src/utils/mount.js
@@ -142,3 +142,58 @@ export function filter (options) {
     done();
   };
 }
+
+export function middleware (options) {
+  return function mount (files, metalsmith, done) {
+    const metadata = metalsmith.metadata();
+
+    let serviceConfigPath = path.resolve(options.mount);
+    let serviceConfigDirname = path.dirname(serviceConfigPath);
+
+    let relativeServiceConfigPath = path.relative(serviceConfigDirname, serviceConfigPath);
+    let existingServiceConfig = require(serviceConfigPath);
+    let serviceConfigChanges = {};
+
+    debug(`Attempting to mount ${options.name} middleware to service at ${serviceConfigPath}`);
+
+    metadata.answers.binding.map((b) => {
+      debug(`Compiling changes for ${b} bindings`);
+
+      if (typeof serviceConfigChanges[b] === 'undefined') {
+        serviceConfigChanges[b] = {};
+      }
+
+      metadata.answers.method.map((m) => {
+        debug(`Compiling changes for ${b} bindings and ${m} method`);
+
+        let hook = {
+          require: './middleware/' + options.name + '.js',
+          options: []
+        };
+
+        if (typeof serviceConfigChanges[b][m] === 'undefined') {
+          serviceConfigChanges[b][m] = [];
+        }
+        serviceConfigChanges[b][m].push(hook);
+      });
+    });
+
+    debug('Proposed service config changes', serviceConfigChanges);
+    let newServiceConfig = merge(existingServiceConfig, serviceConfigChanges);
+    debug('Final service config to be written', newServiceConfig);
+
+    // write out new root config so service is bootstrapped (respect white space)
+    fs.writeFile(serviceConfigPath, JSON.stringify(newServiceConfig, null, 2), function (err) {
+      if (err) {
+        debug(err.stack);
+        return done(err);
+      }
+      debug(`Successfully mounted "${options.name}" middleware to service at ${serviceConfigPath}`);
+      debug(`Service config can be found at ${relativeServiceConfigPath}`);
+      done();
+    });
+
+    done();
+  };
+}
+

--- a/src/utils/rename.js
+++ b/src/utils/rename.js
@@ -71,3 +71,21 @@ export function filter (options) {
     done();
   };
 }
+
+export function middleware (options) {
+  return function rename (files, metalsmith, done) {
+    each(
+      Object.keys(files),
+      function (file, next) {
+        if (match(file, ['*.js']).length) {
+          let newName = file.replace('middleware', options.name);
+          debug(`Renaming template ${file} to ${newName}`);
+          files[newName] = files[file];
+          delete files[file];
+        }
+      }
+    );
+
+    done();
+  };
+}


### PR DESCRIPTION
overview
===

This generator should be able to generate standalone middleware in the current director or by mounting them onto an existing `service.json`. When generating it in standalone mode it would be nice if it also produced the rest of the repo dependencies such as `package.json` etc so it can be published but this should not be the default implementation necessarily.

tasks
===

- [x] build out the middleware generator.js
- [x] build out middleware specific pipeline utils
- [x] copy to appropriate middleware directory
- [x] properly render with handlebars
- [x] rename middleware based on argv
- [x] mount to `service.json` based on method and mount path
- [x] mount to `feathers.json` based on method and mount path
- [x] make sure middleware run from `service.json`
- [x] make sure middleware run `feeathers.json`
- [x] make sure no logs in tests (`NODE_ENV=testing`)

demo
===
TBD

_issue edited by [@slajax](https://github.com/slajax)_
