### PR TITLE
merge when mounting

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "handlebars": "^4.0.5",
     "i": "^0.3.3",
     "lodash.merge": "^4.4.0",
+    "lodash.mergewith": "^4.6.0",
     "metalsmith": "^2.1.0",
     "metalsmith-copy": "^0.3.0",
     "metalsmith-move-up": "^1.0.0",
@@ -90,7 +91,7 @@
     "eslint-if-supported": "^1.0.1",
     "istanbul": "^1.1.0-alpha.1",
     "mocha": "^2.4.5",
-    "shx" : "^0.2.1",
+    "shx": "^0.2.1",
     "semistandard": "^9.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "metalsmith": "^2.1.0",
     "metalsmith-copy": "^0.3.0",
     "metalsmith-move-up": "^1.0.0",
-    "object.assign": "^4.0.3",
     "recast": "^0.11.2",
     "repeating": "^2.0.0",
     "string": "^3.3.1",

--- a/src/utils/json.js
+++ b/src/utils/json.js
@@ -35,4 +35,3 @@ export default function (paths) {
     done();
   };
 }
-

--- a/src/utils/json.js
+++ b/src/utils/json.js
@@ -10,7 +10,6 @@ import Debug from 'debug';
 const debug = Debug('feathers-generator:json');
 
 export default function (paths) {
-
   return function json (files, metalsmith, done) {
     const meta = metalsmith.metadata();
 
@@ -36,3 +35,4 @@ export default function (paths) {
     done();
   };
 }
+

--- a/src/utils/mount.js
+++ b/src/utils/mount.js
@@ -23,7 +23,6 @@ function merge (source, changes) {
   return mergeWith(source, changes, safeMerge);
 }
 
-// Add to use property on feathers.json if --mount defined
 export function services (options) {
   return function mount (files, metalsmith, done) {
     // if not mounting, skip

--- a/src/utils/mount.js
+++ b/src/utils/mount.js
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import Debug from 'debug';
-// import merge from 'object.assign';
 import mergeWith from 'lodash.mergewith';
 import isArray from 'lodash.isarray';
 

--- a/src/utils/mount.js
+++ b/src/utils/mount.js
@@ -1,12 +1,30 @@
 import fs from 'fs';
 import path from 'path';
 import Debug from 'debug';
-import merge from 'object.assign';
+// import merge from 'object.assign';
+import mergeWith from 'lodash.mergewith';
+import isArray from 'lodash.isarray';
 
 let debug = Debug('feathers-generator:mount');
 
-// Add to use property on feathers.json if --mount defined
+/*
+ * @Function merge - safely merges without overwrite of arrays
+ * @argument source <Object> - the original object to merge to
+ * @argument changes <Object> - changes to be merged
+ * @returns <Object> - safely merged configuration object
+ */
+function merge (source, changes) {
+  debug('merging', source, changes);
+  function safeMerge (src, chg) {
+    debug('isArray', src);
+    if (isArray(src)) {
+      return src.concat(chg);
+    }
+  }
+  return mergeWith(source, changes, safeMerge);
+}
 
+// Add to use property on feathers.json if --mount defined
 export function services (options) {
   return function mount (files, metalsmith, done) {
     // if not mounting, skip


### PR DESCRIPTION
### overview

Changes when mounting to `service.json` or `feathers.json` should be properly deep-merged rather then overwritten. 

### tasks

- [x] write local merge function
- [x] setup customizer for merge
- [x] customizer should check if array
- [x] if array, concat source + changes