### PR TITLE
pathing

### DIFF
--- a/src/middleware/templates/middleware.js
+++ b/src/middleware/templates/middleware.js
@@ -1,4 +1,4 @@
-module.exports = function () {
+module.exports = function (options={}) {
   function log () {
     if (process.env.NODE_ENV !== 'testing') {
       console.log(...arguments);
@@ -10,9 +10,8 @@ module.exports = function () {
   log(`For more information how to use middleware see https://docs.feathersjs.com/middleware/readme.html`);
   log(``);
 
-  return function (data, connection, hook) {
+  return function(req, res, next) {
     log(`generated {{options.name}} middleware executed`);
-    data.ran = true;
-    return data;
+    return next();
   };
 };

--- a/src/middleware/templates/middleware.test.js
+++ b/src/middleware/templates/middleware.test.js
@@ -2,8 +2,11 @@ const assert = require('assert');
 const createMiddleware = require('./{{options.name}}');
 
 describe('{{options.name}} middleware tests', function () {
-  it('middleware ran', function () {
+  it('middleware ran', function (done) {
     const mw = createMiddleware();
-    assert.equal(mw({}).ran, true);
+    mw({}, {}, function() {
+      assert(true);
+      done();
+    });
   });
 });

--- a/src/utils/mount.js
+++ b/src/utils/mount.js
@@ -83,7 +83,7 @@ export function hooks (options) {
         debug(`Compiling changes for ${b} bindings and ${m} method`);
 
         let hook = {
-          require: './hooks/' + options.name + '.js',
+          require: './hooks/' + options.name,
           options: []
         };
 
@@ -130,7 +130,7 @@ export function filter (options) {
       debug(`Compiling changes for ${m} method`);
 
       let filters = {
-        require: './filters/' + options.name + '.js',
+        require: './filters/' + options.name,
         options: []
       };
 
@@ -186,8 +186,10 @@ export function middleware (options) {
         metadata.answers.method.map((m) => {
           debug(`Compiling changes for ${b} bindings and ${m} method`);
 
+          let relativePath = path.relative(options.mount, path.join(options.path, options.name));
+
           let hook = {
-            require: path.resolve(options.root, options.path, options.name + '.js'),
+            require: './' + relativePath,
             options: []
           };
 
@@ -207,8 +209,12 @@ export function middleware (options) {
           serviceConfigChanges[b] = {};
         }
 
+        let dir = path.dirname(options.path);
+        let writePath = path.join(options.path, options.name);
+        let relativePath = path.relative(dir, writePath);
+
         let hook = {
-          require: path.resolve(options.root, options.path, options.name + '.js'),
+          require: './' + relativePath,
           options: []
         };
 
@@ -254,7 +260,7 @@ export function plugin (options) {
     debug(`Compiling changes for plugin bindings`);
 
     let hook = {
-      require: path.resolve(options.root, options.path, options.name + '.js'),
+      require: path.resolve(options.root, options.path, options.name),
       options: []
     };
 


### PR DESCRIPTION
overview
===

Currently within the generated `feathers.json` I am using absolute paths when mounting.

This should be revisited and relative paths should be restored for production compatibility.